### PR TITLE
RAINCATCH-1395 - Add console text reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 npm-debug.log
 reports
 .idea
+dump.rdb

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 
 npm-debug.log
 reports
+.idea

--- a/conf.js
+++ b/conf.js
@@ -9,7 +9,7 @@ exports.config = {
     mobile_portal: 'tests/mobile-portal/*.js'
   },
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 300000,
+    defaultTimeoutInterval: 300000
   },
   capabilities: {
     browserName: 'chrome',

--- a/conf.js
+++ b/conf.js
@@ -1,4 +1,5 @@
 const HtmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
+const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 
 exports.config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',
@@ -8,7 +9,7 @@ exports.config = {
     mobile_portal: 'tests/mobile-portal/*.js'
   },
   jasmineNodeOpts: {
-    defaultTimeoutInterval: 300000
+    defaultTimeoutInterval: 300000,
   },
   capabilities: {
     browserName: 'chrome',
@@ -38,6 +39,9 @@ exports.config = {
   onPrepare: function() {
     jasmine.getEnv().addReporter(new HtmlScreenshotReporter({
       dest: "reports/screenshots"
+    }));
+    jasmine.getEnv().addReporter(new SpecReporter({
+      displayStackTrace: 'all'
     }));
   }
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "html-dnd": "^1.2.0",
     "jasmine-reporters": "^2.2.1",
+    "jasmine-spec-reporter": "^4.2.1",
     "lodash": "^4.17.4",
     "protractor": "^5.1.2",
     "protractor-jasmine2-screenshot-reporter": "^0.4.1",

--- a/page-objects/mobile/workorder/selected.po.js
+++ b/page-objects/mobile/workorder/selected.po.js
@@ -1,76 +1,40 @@
 var utils = require('../../../utils');
+var _ = require('lodash');
 
 var SelectedWorkorderPage = function() {
   var locators = {
-    workorderHeader: element(by.css('#content > div.ng-scope.flex > workorder-summary > md-toolbar > div > h3')),
-    workorderDetails: element(by.css('workorder > md-list')).all(by.css('md-list-item')),
-    workSummary: element(by.css('workorder > p')),
-    workflow: element(by.css('#content > div.ng-scope.flex > workorder-summary > div > workorder > md-list > md-list-item:nth-child(6) > div > h3'))
+    detailsListItems: element.all(by.css('workorder md-list md-list-item')),
+    workSummaryDetails: element(by.css('workorder .md-subheader p')),
+    beginWorkflowButton: element(by.css('button[aria-label="Begin Workflow"]')),
+    workFlowResultSection: element(by.css('workorder-submission-result'))
+  };
+
+  var getListItemChildText = function(index) {
+    return locators.detailsListItems.get(index).element(by.css('h3')).getText();
   };
 
   var commands = {
-    selfCheck: function(header) {
-      return locators.workorderHeader.isPresent().then(function(result) {
-        utils.expect.resultIsTrue(result);
-        return locators.workorderHeader.getText();
-      }).then(function(result) {
-        utils.expect.resultIsEqualTo(result, header);
-      });
+    get: {
+      id: _.partial(getListItemChildText, 0),
+      workorderName: _.partial(getListItemChildText, 1),
+      status: _.partial(getListItemChildText, 2),
+      coordinates: _.partial(getListItemChildText, 3),
+      startDate: _.partial(getListItemChildText, 4),
+      startTime: _.partial(getListItemChildText, 5),
+      finishDate: _.partial(getListItemChildText, 6),
+      finishTime: _.partial(getListItemChildText, 7),
     },
-    getDetails: function() {
-      return locators.workorderDetails.map(function(listItem) {
-        var icon = listItem.element(by.css('md-icon.material-icons')).getText();
-        var h3 = listItem.element(by.css('div > h3')).getText();
-        var p = listItem.element(by.css('div > p')).getText();
-        return { icon, h3, p };
-      });
+    beginWorkflow: function() {
+      locators.beginWorkflowButton.click();
     },
-    getStatus: function(details) {
-      var status = details.find(function(elem) {
-        return elem.p === 'Status';
-      });
-      return status;
-    },
-    getCoordinates: function(details, address) {
-      var coordinates = details.find(function(elem) {
-        return elem.p === address;
-      });
-      return coordinates;
-    },
-    getFinishDate: function(details) {
-      var finishDate = details.find(function(elem) {
-        return elem.p === "Finish Date";
-      });
-      return finishDate;
-    },
-    getFinishTime: function(details) {
-      var finishTime = details.find(function(elem) {
-        return elem.p === "Finish Time";
-      });
-      return finishTime;
-    },
-    getAssignee: function(details) {
-      var assignee = details.find(function(elem) {
-        return elem.p === "Asignee";
-      });
-      return assignee;
-    },
-    getTitle: function(details) {
-      var title = details.find(function(elem) {
-        return elem.p === "Workorder title";
-      });
-      return title;
-    },
-    getWorkSummary: function() {
-      return locators.workSummary.getText();
-    },
-    getWorkflow: function() {
-      return locators.workflow.getText();
+    count: function() {
+      locators.detailsListItems.count();
     }
   };
 
   return {
-    locators, commands
+    locators,
+    commands
   };
 };
 

--- a/page-objects/mobile/workorder/selected.po.js
+++ b/page-objects/mobile/workorder/selected.po.js
@@ -1,40 +1,76 @@
 var utils = require('../../../utils');
-var _ = require('lodash');
 
 var SelectedWorkorderPage = function() {
   var locators = {
-    detailsListItems: element.all(by.css('workorder md-list md-list-item')),
-    workSummaryDetails: element(by.css('workorder .md-subheader p')),
-    beginWorkflowButton: element(by.css('button[aria-label="Begin Workflow"]')),
-    workFlowResultSection: element(by.css('workorder-submission-result'))
-  };
-
-  var getListItemChildText = function(index) {
-    return locators.detailsListItems.get(index).element(by.css('h3')).getText();
+    workorderHeader: element(by.css('#content > div.ng-scope.flex > workorder-summary > md-toolbar > div > h3')),
+    workorderDetails: element(by.css('workorder > md-list')).all(by.css('md-list-item')),
+    workSummary: element(by.css('workorder > p')),
+    workflow: element(by.css('#content > div.ng-scope.flex > workorder-summary > div > workorder > md-list > md-list-item:nth-child(6) > div > h3'))
   };
 
   var commands = {
-    get: {
-      id: _.partial(getListItemChildText, 0),
-      workorderName: _.partial(getListItemChildText, 1),
-      status: _.partial(getListItemChildText, 2),
-      coordinates: _.partial(getListItemChildText, 3),
-      startDate: _.partial(getListItemChildText, 4),
-      startTime: _.partial(getListItemChildText, 5),
-      finishDate: _.partial(getListItemChildText, 6),
-      finishTime: _.partial(getListItemChildText, 7),
+    selfCheck: function(header) {
+      return locators.workorderHeader.isPresent().then(function(result) {
+        utils.expect.resultIsTrue(result);
+        return locators.workorderHeader.getText();
+      }).then(function(result) {
+        utils.expect.resultIsEqualTo(result, header);
+      });
     },
-    beginWorkflow: function() {
-      locators.beginWorkflowButton.click();
+    getDetails: function() {
+      return locators.workorderDetails.map(function(listItem) {
+        var icon = listItem.element(by.css('md-icon.material-icons')).getText();
+        var h3 = listItem.element(by.css('div > h3')).getText();
+        var p = listItem.element(by.css('div > p')).getText();
+        return { icon, h3, p };
+      });
     },
-    count: function() {
-      locators.detailsListItems.count();
+    getStatus: function(details) {
+      var status = details.find(function(elem) {
+        return elem.p === 'Status';
+      });
+      return status;
+    },
+    getCoordinates: function(details, address) {
+      var coordinates = details.find(function(elem) {
+        return elem.p === address;
+      });
+      return coordinates;
+    },
+    getFinishDate: function(details) {
+      var finishDate = details.find(function(elem) {
+        return elem.p === "Finish Date";
+      });
+      return finishDate;
+    },
+    getFinishTime: function(details) {
+      var finishTime = details.find(function(elem) {
+        return elem.p === "Finish Time";
+      });
+      return finishTime;
+    },
+    getAssignee: function(details) {
+      var assignee = details.find(function(elem) {
+        return elem.p === "Asignee";
+      });
+      return assignee;
+    },
+    getTitle: function(details) {
+      var title = details.find(function(elem) {
+        return elem.p === "Workorder title";
+      });
+      return title;
+    },
+    getWorkSummary: function() {
+      return locators.workSummary.getText();
+    },
+    getWorkflow: function() {
+      return locators.workflow.getText();
     }
   };
 
   return {
-    locators,
-    commands
+    locators, commands
   };
 };
 

--- a/page-objects/portal/workorder/selected.po.js
+++ b/page-objects/portal/workorder/selected.po.js
@@ -3,8 +3,8 @@ var utils = require('../../../utils');
 var SelectedWorkorderPage = function() {
   var locators = {
     workorderHeader: element(by.css('#content > div.ng-scope.flex > workorder-summary > md-toolbar > div > h3')),
-    workorderDetails: element(by.css('workorder>md-list')).all(by.css('md-list-item')),
-    workSummary: element(by.css('workorder>p')),
+    workorderDetails: element(by.css('workorder > md-list')).all(by.css('md-list-item')),
+    workSummary: element(by.css('workorder > p')),
     workflow: element(by.css('#content > div.ng-scope.flex > workorder-summary > div > workorder > md-list > md-list-item:nth-child(6) > div > h3'))
   };
 
@@ -19,9 +19,9 @@ var SelectedWorkorderPage = function() {
     },
     getDetails: function() {
       return locators.workorderDetails.map(function(listItem) {
-        var icon = listItem.element(by.css('md-icon')).getText();
-        var h3 = listItem.element(by.css('div>h3')).getText();
-        var p = listItem.element(by.css('div>p')).getText();
+        var icon = listItem.element(by.css('md-icon.material-icons')).getText();
+        var h3 = listItem.element(by.css('div > h3')).getText();
+        var p = listItem.element(by.css('div > p')).getText();
         return { icon, h3, p };
       });
     },


### PR DESCRIPTION
**Motivation**

https://issues.jboss.org/browse/RAINCATCH-1395

To add a text reporter to the terminal output to replace the default dots that ~Jasmine provides to provide the developer with a text based report on what tests have run and passed/failed, and to allow the developer to compare the report to the test plan to see if all test cases in the test plan are covered.

**Progress**

- [x] Added a text reporter to provide textual output
- [x] Troubleshooting warning messages (note: these warning messages are from the one function call that is repeated in numerous tests and cannot be removed without significant changes code changes due to the structure of the HTML tags and how protractor sees them - this can be done with RAINCATCH-1396)

**Verification Steps**

`npm install`
`npm run wdm:update`
`npm run wdm:start`
`npm run test-headless:ui`

Text output should be visible in terminal during test run